### PR TITLE
Library Routing

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -7,7 +7,7 @@ import { Entries } from "./requests/Entries.js";
 export const ApplicationViews = () => {
     return (
         <>
-            <Route exact path="/library">
+            <Route exact path={["/library", "/"]}>
                 <Library />
             </Route>
             <Route exact path="/library/:rudimentId(\d+)">


### PR DESCRIPTION
Both '/' and '/library' display the library element, removing confusion if a user were to visit just the URL.