### PR TITLE
Pending Entries Display Rudiment Name

### DIFF
--- a/src/components/data_management/EntriesData.js
+++ b/src/components/data_management/EntriesData.js
@@ -4,7 +4,7 @@ export const getEntryById = (id) => {
     return fetch(`${API}/entries/${id}`).then((res) => res.json());
 };
 export const getPendingEntries = () => {
-    return fetch(`${API}/entries?approved=false&_expand=user`).then((res) => res.json());
+    return fetch(`${API}/entries?approved=false&_expand=user&_expand=rudiment`).then((res) => res.json());
 };
 export const postEntry = (entryObject) => {
     return fetch(`${API}/entries`, postOptions(entryObject));

--- a/src/components/requests/Entry.js
+++ b/src/components/requests/Entry.js
@@ -1,9 +1,10 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export const Entry = ({ entry }) => {
     return (
         <li>
-            {entry.user.name} - {entry.bpm} BPM
+            {entry.user.name} - <Link to={`/library/${entry.rudimentId}`}>{entry.rudiment.name}</Link> - {entry.bpm} BPM
         </li>
     );
 };


### PR DESCRIPTION
The pending entries page now shows the name of the rudiment associated with each entry.

- The entry `<li>` now includes a reference to the rudiment's name that the entry is associated with.
- The rudiment's name is a clickable affordance that will route to that rudiment's detailed view in the library