### PR TITLE
Entry Form and Leaderboard Toggles

### DIFF
--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -57,6 +57,8 @@ export const RudimentDetails = () => {
                 {rudiment.id}. {rudiment.name}
             </h1>
             <img src={rudiment.img} />
+            <button>Create An Entry</button>
+            {lbAccess && <button>View Leaderboard</button>}
             {!entrySubmitted ? (
                 <form>
                     {!isSubmitterStudent && (

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -57,8 +57,14 @@ export const RudimentDetails = () => {
                 {rudiment.id}. {rudiment.name}
             </h1>
             <img src={rudiment.img} />
-            <button>Create An Entry</button>
-            {lbAccess && <button>View Leaderboard</button>}
+            <button onClick={() => (userView === "entry" ? setUserView("none") : setUserView("entry"))}>
+                Create An Entry
+            </button>
+            {lbAccess && (
+                <button onClick={() => (userView === "lb" ? setUserView("none") : setUserView("lb"))}>
+                    View Leaderboard
+                </button>
+            )}
             {!entrySubmitted ? (
                 <form>
                     {!isSubmitterStudent && (

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -15,6 +15,7 @@ export const RudimentDetails = () => {
     const [entrySubmitted, setSubmitState] = useState(false);
     const [isSubmitterStudent, setSubmitter] = useState(false);
     const [lbAccess, setLb] = useState(false);
+    const [userView, setUserView] = useState("none");
     const { rudimentId } = useParams();
 
     useEffect(() => {

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -65,7 +65,7 @@ export const RudimentDetails = () => {
                     View Leaderboard
                 </button>
             )}
-            {!entrySubmitted ? (
+            {!entrySubmitted && userView === "entry" ? (
                 <form>
                     {!isSubmitterStudent && (
                         <>
@@ -89,8 +89,10 @@ export const RudimentDetails = () => {
                         Submit Entry
                     </button>
                 </form>
-            ) : (
+            ) : entrySubmitted ? (
                 <p>Submission Complete</p>
+            ) : (
+                ""
             )}
             {rudiment.id && lbAccess && <Leaderboard rudiment={rudiment} />}
         </>

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -94,7 +94,7 @@ export const RudimentDetails = () => {
             ) : (
                 ""
             )}
-            {rudiment.id && lbAccess && <Leaderboard rudiment={rudiment} />}
+            {rudiment.id && lbAccess && userView === "lb" && <Leaderboard rudiment={rudiment} />}
         </>
     );
 };


### PR DESCRIPTION
When a user views a rudiment's detailed view, they will see buttons to toggle leaderboard/entry creation view.

- By default, neither the leaderboard nor the entry form will be displayed
- If a view is selected, selecting it again will close it
- If a view is selected, selecting the other one closes the currently open one and replaces it with the selected one
- View Leaderboard button will only appear if the user has access to the leaderboard

Closes #29
Closes #28 