### PR TITLE
Custom Rudiments View

### DIFF
--- a/src/components/data_management/StudentsProfileData.js
+++ b/src/components/data_management/StudentsProfileData.js
@@ -4,6 +4,9 @@ export const StudentsProfileData = {
     async getStudentProfiles() {
         return await fetch(`${API}/studentsProfile`).then((res) => res.json());
     },
+    async getProfileById(id) {
+        return await fetch(`${API}/studentsProfile/${id}`).then((res) => res.json());
+    },
     async postStudentProfile(userProfile) {
         return await fetch(`${API}/studentsProfile`, postOptions(userProfile));
     },

--- a/src/components/library/CustomRudiments.js
+++ b/src/components/library/CustomRudiments.js
@@ -1,0 +1,11 @@
+import React, { useEffect, useState } from "react";
+
+export const CustomRudiments = ({ rudiments }) => {
+    const [customRudes, setRudes] = useState([]);
+
+    useEffect(() => {
+        const filteredRudes = rudiments.filter((rudiment) => Object.hasOwn(rudiment, "userId"));
+        setRudes(filteredRudes);
+    }, [rudiments]);
+    return <></>;
+};

--- a/src/components/library/CustomRudiments.js
+++ b/src/components/library/CustomRudiments.js
@@ -1,11 +1,23 @@
 import React, { useEffect, useState } from "react";
+import { currentUserId } from "../data_management/Fetch.js";
+import { StudentsProfileData } from "../data_management/StudentsProfileData.js";
 
-export const CustomRudiments = ({ rudiments }) => {
+export const CustomRudiments = ({ rudiments, isViewerStudent }) => {
     const [customRudes, setRudes] = useState([]);
 
     useEffect(() => {
         const filteredRudes = rudiments.filter((rudiment) => Object.hasOwn(rudiment, "userId"));
-        setRudes(filteredRudes);
-    }, [rudiments]);
+        if (isViewerStudent) {
+            StudentsProfileData.getProfileById(currentUserId()).then((sp) => {
+                const instructorRudes = filteredRudes.filter((rude) => rude.userId === sp.instructorId);
+                console.log(instructorRudes);
+                setRudes(instructorRudes);
+            });
+        } else {
+            const myRudes = filteredRudes.filter((rude) => rude.userId === currentUserId());
+            console.log(myRudes);
+            setRudes(myRudes);
+        }
+    }, [rudiments, isViewerStudent]);
     return <></>;
 };

--- a/src/components/library/CustomRudiments.js
+++ b/src/components/library/CustomRudiments.js
@@ -1,23 +1,29 @@
 import React, { useEffect, useState } from "react";
 import { currentUserId } from "../data_management/Fetch.js";
 import { StudentsProfileData } from "../data_management/StudentsProfileData.js";
+import { Rudiment } from "./Rudiment.js";
 
 export const CustomRudiments = ({ rudiments, isViewerStudent }) => {
     const [customRudes, setRudes] = useState([]);
 
     useEffect(() => {
-        const filteredRudes = rudiments.filter((rudiment) => Object.hasOwn(rudiment, "userId"));
         if (isViewerStudent) {
             StudentsProfileData.getProfileById(currentUserId()).then((sp) => {
-                const instructorRudes = filteredRudes.filter((rude) => rude.userId === sp.instructorId);
+                const instructorRudes = rudiments.filter((rude) => rude.userId === sp.instructorId);
                 console.log(instructorRudes);
                 setRudes(instructorRudes);
             });
         } else {
-            const myRudes = filteredRudes.filter((rude) => rude.userId === currentUserId());
+            const myRudes = rudiments.filter((rude) => rude.userId === currentUserId());
             console.log(myRudes);
             setRudes(myRudes);
         }
     }, [rudiments, isViewerStudent]);
-    return <></>;
+    return (
+        <>
+            {customRudes.map((rude) => (
+                <Rudiment key={rude.id} rudiment={rude} />
+            ))}
+        </>
+    );
 };

--- a/src/components/library/Library.js
+++ b/src/components/library/Library.js
@@ -7,11 +7,26 @@ import { RudimentForm } from "./RudimentForm.js";
 import { CustomRudiments } from "./CustomRudiments.js";
 
 export const Library = () => {
-    const [rudiments, setRudiments] = useState([]);
+    const [baseRudiments, setBaseRudiments] = useState([]);
+    const [customRudiments, setCustomRudiments] = useState([]);
     const [isViewerStudent, setViewer] = useState(false);
     const [displayForm, setForm] = useState(false);
 
-    const rudimentsSetter = () => RudimentsData.getAllRudiments().then((rudimentArr) => setRudiments(rudimentArr));
+    const rudimentsSetter = () => {
+        return RudimentsData.getAllRudiments().then((rudimentArr) => {
+            const baseArr = [];
+            const customArr = [];
+            for (const rude of rudimentArr) {
+                if (rude.userId === 1) {
+                    baseArr.push(rude);
+                } else {
+                    customArr.push(rude);
+                }
+            }
+            setBaseRudiments(baseArr);
+            setCustomRudiments(customArr);
+        });
+    };
 
     useEffect(() => {
         rudimentsSetter();
@@ -20,12 +35,16 @@ export const Library = () => {
 
     return (
         <>
+            <h2>Library</h2>
             <ul className="rudimentList">
-                {rudiments.map((rudiment) => (
+                {baseRudiments.map((rudiment) => (
                     <Rudiment key={rudiment.id} rudiment={rudiment} />
                 ))}
             </ul>
-            <ul>{rudiments && <CustomRudiments isViewerStudent={isViewerStudent} rudiments={rudiments} />}</ul>
+            <h2>Custom Excercises</h2>
+            <ul>
+                {customRudiments && <CustomRudiments isViewerStudent={isViewerStudent} rudiments={customRudiments} />}
+            </ul>
             {!isViewerStudent && displayForm ? (
                 <>
                     <button onClick={() => setForm(false)}>-</button>

--- a/src/components/library/Library.js
+++ b/src/components/library/Library.js
@@ -8,7 +8,7 @@ import { CustomRudiments } from "./CustomRudiments.js";
 
 export const Library = () => {
     const [rudiments, setRudiments] = useState([]);
-    const [isViewerStudent, setViewer] = useState(true);
+    const [isViewerStudent, setViewer] = useState(false);
     const [displayForm, setForm] = useState(false);
 
     const rudimentsSetter = () => RudimentsData.getAllRudiments().then((rudimentArr) => setRudiments(rudimentArr));
@@ -25,7 +25,7 @@ export const Library = () => {
                     <Rudiment key={rudiment.id} rudiment={rudiment} />
                 ))}
             </ul>
-            <ul>{rudiments && <CustomRudiments rudiments={rudiments} />}</ul>
+            <ul>{rudiments && <CustomRudiments isViewerStudent={isViewerStudent} rudiments={rudiments} />}</ul>
             {!isViewerStudent && displayForm ? (
                 <>
                     <button onClick={() => setForm(false)}>-</button>

--- a/src/components/library/Library.js
+++ b/src/components/library/Library.js
@@ -4,6 +4,7 @@ import { UsersData } from "../data_management/UsersData.js";
 import { Rudiment } from "./Rudiment.js";
 import "./Library.css";
 import { RudimentForm } from "./RudimentForm.js";
+import { CustomRudiments } from "./CustomRudiments.js";
 
 export const Library = () => {
     const [rudiments, setRudiments] = useState([]);
@@ -24,6 +25,7 @@ export const Library = () => {
                     <Rudiment key={rudiment.id} rudiment={rudiment} />
                 ))}
             </ul>
+            <ul>{rudiments && <CustomRudiments rudiments={rudiments} />}</ul>
             {!isViewerStudent && displayForm ? (
                 <>
                     <button onClick={() => setForm(false)}>-</button>


### PR DESCRIPTION
Custom rudiments have their own dedicated section in the library, and only relevant custom rudiments display.

- The main 40 rudiments are sorted in their own grouping on the library page, this information is displayed to the user.
- Custom rudiments are displayed below the main 40.
- Custom rudiments are filtered to only show to a student their instructor's rudiments, or to the instructor their created rudiments.

Closes #49 