### PR TITLE
Custom Rudiment File Upload

### DIFF
--- a/src/components/library/CustomRudiments.js
+++ b/src/components/library/CustomRudiments.js
@@ -10,12 +10,10 @@ export const CustomRudiments = ({ rudiments, isViewerStudent }) => {
         if (isViewerStudent) {
             StudentsProfileData.getProfileById(currentUserId()).then((sp) => {
                 const instructorRudes = rudiments.filter((rude) => rude.userId === sp.instructorId);
-                console.log(instructorRudes);
                 setRudes(instructorRudes);
             });
         } else {
             const myRudes = rudiments.filter((rude) => rude.userId === currentUserId());
-            console.log(myRudes);
             setRudes(myRudes);
         }
     }, [rudiments, isViewerStudent]);

--- a/src/components/library/ImageUpload.js
+++ b/src/components/library/ImageUpload.js
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+
+export const ImageUpload = ({ urlSetter, urlStatus }) => {
+    const [uploading, setUploading] = useState(false);
+
+    const uploadImage = async (e) => {
+        const files = e.target.files;
+        const data = new FormData();
+        data.append("file", files[0]);
+        data.append("upload_preset", "customRudiments");
+        setUploading(true);
+
+        const res = await fetch(`https://api.cloudinary.com/v1_1/dcfyvy9gb/image/upload`, {
+            method: "POST",
+            body: data,
+        });
+
+        const file = await res.json();
+
+        urlSetter(file.secure_url);
+
+        setUploading(false);
+    };
+
+    return (
+        <label htmlFor="upload">
+            <input type="file" name="upload" accept="image/*" placeholder="Upload Image" onChange={uploadImage} />
+            {uploading ? <p>Uploading...</p> : !uploading && urlStatus?.length > 0 ? <p>Upload Complete</p> : ""}
+        </label>
+    );
+};

--- a/src/components/library/RudimentForm.js
+++ b/src/components/library/RudimentForm.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { currentUserId } from "../data_management/Fetch.js";
 import { RudimentsData } from "../data_management/RudimentsData.js";
+import { ImageUpload } from "./ImageUpload.js";
 
 export const RudimentForm = ({ stateSetter }) => {
     const [rudeName, setRude] = useState("");
@@ -25,6 +26,7 @@ export const RudimentForm = ({ stateSetter }) => {
                 Image URL
                 <input type="text" name="url" placeholder="URL" onChange={(e) => setUrl(e.target.value)} />
             </label>
+            <ImageUpload urlSetter={setUrl} urlStatus={rudeUrl} />
             <button type="button" onClick={() => postRude()}>
                 Create Excercise
             </button>

--- a/src/components/library/RudimentForm.js
+++ b/src/components/library/RudimentForm.js
@@ -6,6 +6,7 @@ import { ImageUpload } from "./ImageUpload.js";
 export const RudimentForm = ({ stateSetter }) => {
     const [rudeName, setRude] = useState("");
     const [rudeUrl, setUrl] = useState("");
+    const [uploadFile, setUploadFile] = useState(false);
 
     const postRude = () => {
         const rudiment = {
@@ -17,19 +18,30 @@ export const RudimentForm = ({ stateSetter }) => {
     };
 
     return (
-        <>
+        <div>
             <label htmlFor="name">
                 Excercise Name
                 <input type="text" name="name" placeholder="Exercise Name" onChange={(e) => setRude(e.target.value)} />
             </label>
-            <label htmlFor="url">
-                Image URL
-                <input type="text" name="url" placeholder="URL" onChange={(e) => setUrl(e.target.value)} />
+            <label>
+                Upload Image via URL
+                <input type="radio" name="uploadType" checked={!uploadFile} onChange={() => setUploadFile(false)} />
             </label>
-            <ImageUpload urlSetter={setUrl} urlStatus={rudeUrl} />
+            <label>
+                Upload Image via File
+                <input type="radio" name="uploadType" checked={uploadFile} onChange={() => setUploadFile(true)} />
+            </label>
+            {uploadFile ? (
+                <ImageUpload urlSetter={setUrl} urlStatus={rudeUrl} />
+            ) : (
+                <label htmlFor="url">
+                    Image URL
+                    <input type="text" name="url" placeholder="URL" onChange={(e) => setUrl(e.target.value)} />
+                </label>
+            )}
             <button type="button" onClick={() => postRude()}>
                 Create Excercise
             </button>
-        </>
+        </div>
     );
 };

--- a/src/components/library/RudimentForm.js
+++ b/src/components/library/RudimentForm.js
@@ -25,11 +25,27 @@ export const RudimentForm = ({ stateSetter }) => {
             </label>
             <label>
                 Upload Image via URL
-                <input type="radio" name="uploadType" checked={!uploadFile} onChange={() => setUploadFile(false)} />
+                <input
+                    type="radio"
+                    name="uploadType"
+                    checked={!uploadFile}
+                    onChange={() => {
+                        setUploadFile(false);
+                        setUrl("");
+                    }}
+                />
             </label>
             <label>
                 Upload Image via File
-                <input type="radio" name="uploadType" checked={uploadFile} onChange={() => setUploadFile(true)} />
+                <input
+                    type="radio"
+                    name="uploadType"
+                    checked={uploadFile}
+                    onChange={() => {
+                        setUploadFile(true);
+                        setUrl("");
+                    }}
+                />
             </label>
             {uploadFile ? (
                 <ImageUpload urlSetter={setUrl} urlStatus={rudeUrl} />


### PR DESCRIPTION
A user is now able to upload an image via file rather than just URL when creating a rudiment

- If user is an instructor and navigates to the rudiment creation form, they will see two radio buttons - one to select uploading via URL (default) and one to select uploading via file
- The user's uploaded file will be uploaded to Cloudinary and the secure URL of the file will be assigned to the new entry object
- The user will be informed when their file has finished uploading
- Every time a user changes one of the radio buttons, the state of the URL entry is reset to avoid false confirmation message and invalid URLs

Closes #60 
Closes #47 