### PR TITLE
Rudiment Deletion

### DIFF
--- a/src/components/data_management/RudimentsData.js
+++ b/src/components/data_management/RudimentsData.js
@@ -11,6 +11,6 @@ export const RudimentsData = {
         return await fetch(`${API}/rudiments`, postOptions(obj));
     },
     async deleteRudiment(id) {
-        return await fetch(`${API}/rudiments/${id}`), {method: "DELETE"}
+        return await fetch(`${API}/rudiments/${id}`, {method: "DELETE"})
     }
 };

--- a/src/components/data_management/RudimentsData.js
+++ b/src/components/data_management/RudimentsData.js
@@ -10,4 +10,7 @@ export const RudimentsData = {
     async postRudiment(obj) {
         return await fetch(`${API}/rudiments`, postOptions(obj));
     },
+    async deleteRudiment(id) {
+        return await fetch(`${API}/rudiments/${id}`), {method: "DELETE"}
+    }
 };

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -68,6 +68,7 @@ export const RudimentDetails = () => {
                             </Button>
                         )}
                     </Col>
+                    {currentUserId() === rudiment.userId && <Col sm="auto"><Button variant="danger">Delete Rudiment</Button></Col>}
                 </Row>
                 {showMetronome && (
                     <div className="metronome mx-auto mt-3">

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -9,7 +9,7 @@ import Metronome from "@kevinorriss/react-metronome";
 import "./RudimentDetails.css";
 import { EntryForm } from "./EntryForm.js";
 import Button from "react-bootstrap/Button";
-import { Card, Container, Row, Col } from "react-bootstrap";
+import { Card, Container, Row, Col, Modal } from "react-bootstrap";
 
 export const RudimentDetails = () => {
     const [rudiment, setRudiment] = useState({});
@@ -19,6 +19,7 @@ export const RudimentDetails = () => {
     const [lbAccess, setLb] = useState(false);
     const [userView, setUserView] = useState("none");
     const [showMetronome, setMetronome] = useState(false);
+    const [showDelete, setDelete] = useState(false)
     const { rudimentId } = useParams();
 
     useEffect(() => {
@@ -44,6 +45,20 @@ export const RudimentDetails = () => {
     return (
         <>
             <Container>
+            <Modal show={showDelete} onHide={() => setDelete(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete Rudiment</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Are you sure you want to delete this rudiment? This action cannot be undone.</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setDelete(false)}>
+            No, Take Me Back!
+          </Button>
+          <Button variant="danger" onClick={() => {}}>
+            Yes, Delete.
+          </Button>
+        </Modal.Footer>
+      </Modal>
                 <Card className="mt-3">
                     <Card.Title>
                         <h1 className="text-center">
@@ -68,7 +83,7 @@ export const RudimentDetails = () => {
                             </Button>
                         )}
                     </Col>
-                    {currentUserId() === rudiment.userId && <Col sm="auto"><Button variant="danger">Delete Rudiment</Button></Col>}
+                    {currentUserId() === rudiment.userId && <Col sm="auto"><Button onClick={() => setDelete(true)} variant="danger">Delete Rudiment</Button></Col>}
                 </Row>
                 {showMetronome && (
                     <div className="metronome mx-auto mt-3">

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -10,6 +10,7 @@ import "./RudimentDetails.css";
 import { EntryForm } from "./EntryForm.js";
 import Button from "react-bootstrap/Button";
 import { Card, Container, Row, Col, Modal } from "react-bootstrap";
+import { useHistory } from "react-router-dom";
 
 export const RudimentDetails = () => {
     const [rudiment, setRudiment] = useState({});
@@ -20,6 +21,7 @@ export const RudimentDetails = () => {
     const [userView, setUserView] = useState("none");
     const [showMetronome, setMetronome] = useState(false);
     const [showDelete, setDelete] = useState(false)
+    const history = useHistory()
     const { rudimentId } = useParams();
 
     useEffect(() => {
@@ -42,23 +44,26 @@ export const RudimentDetails = () => {
         }
     }, [isSubmitterStudent]);
 
+    const rudimentDelete = () => {
+        RudimentsData.deleteRudiment(rudimentId).then(() => history.push("/library"))
+    }
+
     return (
-        <>
             <Container>
-            <Modal show={showDelete} onHide={() => setDelete(false)}>
-        <Modal.Header closeButton>
-          <Modal.Title>Delete Rudiment</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>Are you sure you want to delete this rudiment? This action cannot be undone.</Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary" onClick={() => setDelete(false)}>
-            No, Take Me Back!
-          </Button>
-          <Button variant="danger" onClick={() => {}}>
-            Yes, Delete.
-          </Button>
-        </Modal.Footer>
-      </Modal>
+                <Modal show={showDelete} onHide={() => setDelete(false)}>
+                    <Modal.Header closeButton>
+                      <Modal.Title>Delete Rudiment</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>Are you sure you want to delete this rudiment? This action cannot be undone.</Modal.Body>
+                    <Modal.Footer>
+                        <Button variant="secondary" onClick={() => setDelete(false)}>
+                            No, Take Me Back!
+                        </Button>
+                        <Button variant="danger" onClick={() => rudimentDelete()}>
+                            Yes, Delete.
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
                 <Card className="mt-3">
                     <Card.Title>
                         <h1 className="text-center">
@@ -104,6 +109,5 @@ export const RudimentDetails = () => {
                 )}
                 {rudiment.id && lbAccess && userView === "lb" && <Leaderboard rudiment={rudiment} />}
             </Container>
-        </>
     );
 };


### PR DESCRIPTION
Added the ability for an instructor to delete their custom rudiment.

- If an instructor is logged in and is viewing a custom rudiment they created, the instructor will have the option to delete their rudiment.
- The delete button on the page does not delete the rudiment immediately and instead asks the user again if they're sure they want to delete the rudiment.

Resolves #78 