### PR TITLE
Rudiment Buttons Redesign

### DIFF
--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -18,7 +18,6 @@ export const RudimentDetails = () => {
     const [isSubmitterStudent, setSubmitter] = useState(false);
     const [lbAccess, setLb] = useState(false);
     const [userView, setUserView] = useState("none");
-    const [showMetronome, setMetronome] = useState(false);
     const [showDelete, setDelete] = useState(false);
     const history = useHistory();
     const { rudimentId } = useParams();

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -8,8 +8,7 @@ import { currentUserId } from "../data_management/Fetch.js";
 import Metronome from "@kevinorriss/react-metronome";
 import "./RudimentDetails.css";
 import { EntryForm } from "./EntryForm.js";
-import Button from "react-bootstrap/Button";
-import { Card, Container, Row, Col, Modal } from "react-bootstrap";
+import { Card, Container, Row, Col, Modal, ButtonGroup, Button, ToggleButton } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 
 export const RudimentDetails = () => {
@@ -20,8 +19,8 @@ export const RudimentDetails = () => {
     const [lbAccess, setLb] = useState(false);
     const [userView, setUserView] = useState("none");
     const [showMetronome, setMetronome] = useState(false);
-    const [showDelete, setDelete] = useState(false)
-    const history = useHistory()
+    const [showDelete, setDelete] = useState(false);
+    const history = useHistory();
     const { rudimentId } = useParams();
 
     useEffect(() => {
@@ -45,69 +44,96 @@ export const RudimentDetails = () => {
     }, [isSubmitterStudent]);
 
     const rudimentDelete = () => {
-        RudimentsData.deleteRudiment(rudimentId).then(() => history.push("/library"))
-    }
+        RudimentsData.deleteRudiment(rudimentId).then(() => history.push("/library"));
+    };
+
+    const handleUserView = (str) => {
+        if (userView === str) {
+            return setUserView("none");
+        } else {
+            return setUserView(str);
+        }
+    };
 
     return (
-            <Container>
-                <Modal show={showDelete} onHide={() => setDelete(false)}>
-                    <Modal.Header closeButton>
-                      <Modal.Title>Delete Rudiment</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>Are you sure you want to delete this rudiment? This action cannot be undone.</Modal.Body>
-                    <Modal.Footer>
-                        <Button variant="secondary" onClick={() => setDelete(false)}>
-                            No, Take Me Back!
-                        </Button>
-                        <Button variant="danger" onClick={() => rudimentDelete()}>
-                            Yes, Delete.
-                        </Button>
-                    </Modal.Footer>
-                </Modal>
-                <Card className="mt-3">
-                    <Card.Title>
-                        <h1 className="text-center">
-                            {rudiment.id}. {rudiment.name}
-                        </h1>
-                    </Card.Title>
-                    <Card.Img src={rudiment.img} />
-                </Card>
-                <Row className="justify-content-sm-center pt-3">
+        <Container>
+            <Modal show={showDelete} onHide={() => setDelete(false)}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Delete Rudiment</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>Are you sure you want to delete this rudiment? This action cannot be undone.</Modal.Body>
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={() => setDelete(false)}>
+                        No, Take Me Back!
+                    </Button>
+                    <Button variant="danger" onClick={() => rudimentDelete()}>
+                        Yes, Delete.
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+            <Card className="mt-3">
+                <Card.Title>
+                    <h1 className="text-center">
+                        {rudiment.id}. {rudiment.name}
+                    </h1>
+                </Card.Title>
+                <Card.Img src={rudiment.img} />
+            </Card>
+            <Row className="justify-content-sm-center pt-3">
+                <ButtonGroup type="radio" name="userView" value={userView} onChange={handleUserView}>
+                    <ToggleButton
+                        variant="outline-info"
+                        type="radio"
+                        checked={userView === "metronome"}
+                        onClick={() => (userView === "metronome" ? setUserView("none") : setUserView("metronome"))}
+                    >
+                        Metronome
+                    </ToggleButton>
+                    <ToggleButton
+                        variant="outline-info"
+                        type="radio"
+                        checked={userView === "entry"}
+                        onClick={() => (userView === "entry" ? setUserView("none") : setUserView("entry"))}
+                    >
+                        Create An Entry
+                    </ToggleButton>
+                    {lbAccess && (
+                        <ToggleButton
+                            variant="outline-info"
+                            type="radio"
+                            checked={userView === "lb"}
+                            onClick={() => (userView === "lb" ? setUserView("none") : setUserView("lb"))}
+                        >
+                            View Leaderboard
+                        </ToggleButton>
+                    )}
+                </ButtonGroup>
+                {currentUserId() === rudiment.userId && (
                     <Col sm="auto">
-                        <Button onClick={() => setMetronome(!showMetronome)}>Metronome</Button>
-                    </Col>
-                    <Col sm="auto">
-                        <Button onClick={() => (userView === "entry" ? setUserView("none") : setUserView("entry"))}>
-                            Create An Entry
+                        <Button onClick={() => setDelete(true)} variant="danger">
+                            Delete Rudiment
                         </Button>
                     </Col>
-                    <Col sm="auto">
-                        {lbAccess && (
-                            <Button onClick={() => (userView === "lb" ? setUserView("none") : setUserView("lb"))}>
-                                View Leaderboard
-                            </Button>
-                        )}
-                    </Col>
-                    {currentUserId() === rudiment.userId && <Col sm="auto"><Button onClick={() => setDelete(true)} variant="danger">Delete Rudiment</Button></Col>}
-                </Row>
-                {showMetronome && (
-                    <div className="metronome mx-auto mt-3">
-                        <Metronome startBpm={120} />
-                    </div>
                 )}
-                {!entrySubmitted && userView === "entry" ? (
-                    <EntryForm
-                        students={students}
-                        isStudent={isSubmitterStudent}
-                        rudimentId={rudimentId}
-                        setSubmitState={setSubmitState}
-                    />
-                ) : entrySubmitted ? (
-                    <p>Submission Complete</p>
-                ) : (
-                    ""
-                )}
-                {rudiment.id && lbAccess && userView === "lb" && <Leaderboard rudiment={rudiment} />}
-            </Container>
+            </Row>
+            {userView === "metronome" && (
+                <div className="metronome mx-auto mt-3">
+                    <Metronome startBpm={120} />
+                </div>
+            )}
+            {!entrySubmitted && userView === "entry" ? (
+                <EntryForm
+                    students={students}
+                    isStudent={isSubmitterStudent}
+                    rudimentId={rudimentId}
+                    setSubmitState={setSubmitState}
+                />
+            ) : entrySubmitted ? (
+                <p>Submission Complete</p>
+            ) : (
+                ""
+            )}
+            {rudiment.id && lbAccess && userView === "lb" && <Leaderboard rudiment={rudiment} />}
+        </Container>
     );
 };

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -74,7 +74,7 @@ export const RudimentDetails = () => {
                 <Card.Title>
                     <Row>
                         <Col />
-                        <Col>
+                        <Col xs={6}>
                             <h1 className="text-center">
                                 {rudiment.id}. {rudiment.name}
                             </h1>

--- a/src/components/library/RudimentDetails.js
+++ b/src/components/library/RudimentDetails.js
@@ -73,9 +73,21 @@ export const RudimentDetails = () => {
             </Modal>
             <Card className="mt-3">
                 <Card.Title>
-                    <h1 className="text-center">
-                        {rudiment.id}. {rudiment.name}
-                    </h1>
+                    <Row>
+                        <Col />
+                        <Col>
+                            <h1 className="text-center">
+                                {rudiment.id}. {rudiment.name}
+                            </h1>
+                        </Col>
+                        <Col className="my-auto d-flex justify-content-end">
+                            {currentUserId() === rudiment.userId && (
+                                <Button className="me-5" onClick={() => setDelete(true)} variant="danger">
+                                    Delete Rudiment
+                                </Button>
+                            )}
+                        </Col>
+                    </Row>
                 </Card.Title>
                 <Card.Img src={rudiment.img} />
             </Card>
@@ -108,13 +120,6 @@ export const RudimentDetails = () => {
                         </ToggleButton>
                     )}
                 </ButtonGroup>
-                {currentUserId() === rudiment.userId && (
-                    <Col sm="auto">
-                        <Button onClick={() => setDelete(true)} variant="danger">
-                            Delete Rudiment
-                        </Button>
-                    </Col>
-                )}
             </Row>
             {userView === "metronome" && (
                 <div className="metronome mx-auto mt-3">


### PR DESCRIPTION
Redesigned the buttons in the rudiment detail view.

- Delete button positioned next to rudiment name
- Buttons are now grouped together and styled with outline
- Button group spans the width of the container, matching the card
- Each button may be toggled to display only one user view at a time
- When a button is toggled, the button indicates it, even after clicking off of the button